### PR TITLE
refactor: streamlined adonis-typings so functionality is more in line…

### DIFF
--- a/adonis-typings/logger.ts
+++ b/adonis-typings/logger.ts
@@ -56,7 +56,7 @@ declare module '@ioc:Adonis/Core/Logger' {
    */
   interface LogLevelFn {
     (message: string, ...values: any[]): void
-    (mergingObject: any, message: string, ...values: any[]): void
+    (mergingObject: object, message?: string, ...values: any[]): void
   }
 
   /**

--- a/adonis-typings/logger.ts
+++ b/adonis-typings/logger.ts
@@ -52,6 +52,14 @@ declare module '@ioc:Adonis/Core/Logger' {
   }
 
   /**
+   * Generic interface for all log levels
+   */
+  interface LogLevelFn {
+    (message: string, ...values: any[]): void
+    (mergingObject: any, message: string, ...values: any[]): void
+  }
+
+  /**
    * Logger interface that main and fake logger implements
    */
   export interface LoggerContract {
@@ -61,25 +69,19 @@ declare module '@ioc:Adonis/Core/Logger' {
     pinoVersion: string,
 
     log (level: string, message: string, ...values: any[]): void
-    log (level: string, mergingObject: any, message: string, ...values: any[]): void
+    log (level: string, mergingObject: object, message: string, ...values: any[]): void
 
-    trace (message: string, ...values: any[]): void
-    trace (mergingObject: any, message: string, ...values: any[]): void
+    trace: LogLevelFn
 
-    debug (message: string, ...values: any[]): void
-    debug (mergingObject: any, message: string, ...values: any[]): void
+    debug: LogLevelFn
 
-    info (message: string, ...values: any[]): void
-    info (mergingObject: any, message: string, ...values: any[]): void
+    info: LogLevelFn
 
-    warn (message: string, ...values: any[]): void
-    warn (mergingObject: any, message: string, ...values: any[]): void
+    warn: LogLevelFn
 
-    error (message: string, ...values: any[]): void
-    error (mergingObject: any, message: string, ...values: any[]): void
+    error: LogLevelFn
 
-    fatal (message: string, ...values: any[]): void
-    fatal (mergingObject: any, message: string, ...values: any[]): void
+    fatal: LogLevelFn
 
     isLevelEnabled (level: string): boolean,
     bindings (): { [key: string]: any },

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -108,8 +108,8 @@ export class Logger implements LoggerContract {
    * Log message for any named level
    */
   public log (level: string, message: string, ...values: any[]): void
-  public log (level: string, mergingObject: any, message: string, ...values: any[]): void
-  public log (level: string, mergingObject: any, message: string, ...values: any[]): void {
+  public log (level: string, mergingObject: object, message?: string, ...values: any[]): void
+  public log (level: string, mergingObject: any, message?: string, ...values: any[]): void {
     if (values.length) {
       this.pino[level](mergingObject, message, ...values)
     } else if (message) {
@@ -123,8 +123,8 @@ export class Logger implements LoggerContract {
    * Log message at trace level
    */
   public trace (message: string, ...values: any[]): void
-  public trace (mergingObject: any, message: string, ...values: any[]): void
-  public trace (mergingObject: any, message: string, ...values: any[]): void {
+  public trace (mergingObject: object, message?: string, ...values: any[]): void
+  public trace (mergingObject: any, message?: string, ...values: any[]): void {
     this.log('trace', mergingObject, message, ...values)
   }
 
@@ -132,8 +132,8 @@ export class Logger implements LoggerContract {
    * Log message at debug level
    */
   public debug (message: string, ...values: any[]): void
-  public debug (mergingObject: any, message: string, ...values: any[]): void
-  public debug (mergingObject: any, message: string, ...values: any[]): void {
+  public debug (mergingObject: object, message?: string, ...values: any[]): void
+  public debug (mergingObject: any, message?: string, ...values: any[]): void {
     this.log('debug', mergingObject, message, ...values)
   }
 
@@ -141,8 +141,8 @@ export class Logger implements LoggerContract {
    * Log message at info level
    */
   public info (message: string, ...values: any[]): void
-  public info (mergingObject: any, message: string, ...values: any[]): void
-  public info (mergingObject: any, message: string, ...values: any[]): void {
+  public info (mergingObject: object, message?: string, ...values: any[]): void
+  public info (mergingObject: any, message?: string, ...values: any[]): void {
     this.log('info', mergingObject, message, ...values)
   }
 
@@ -150,8 +150,8 @@ export class Logger implements LoggerContract {
    * Log message at warn level
    */
   public warn (message: string, ...values: any[]): void
-  public warn (mergingObject: any, message: string, ...values: any[]): void
-  public warn (mergingObject: any, message: string, ...values: any[]): void {
+  public warn (mergingObject: object, message?: string, ...values: any[]): void
+  public warn (mergingObject: any, message?: string, ...values: any[]): void {
     this.log('warn', mergingObject, message, ...values)
   }
 
@@ -159,8 +159,8 @@ export class Logger implements LoggerContract {
    * Log message at error level
    */
   public error (message: string, ...values: any[]): void
-  public error (mergingObject: any, message: string, ...values: any[]): void
-  public error (mergingObject: any, message: string, ...values: any[]): void {
+  public error (mergingObject: object, message?: string, ...values: any[]): void
+  public error (mergingObject: any, message?: string, ...values: any[]): void {
     this.log('error', mergingObject, message, ...values)
   }
 
@@ -168,8 +168,8 @@ export class Logger implements LoggerContract {
    * Log message at fatal level
    */
   public fatal (message: string, ...values: any[]): void
-  public fatal (mergingObject: any, message: string, ...values: any[]): void
-  public fatal (mergingObject: any, message: string, ...values: any[]): void {
+  public fatal (mergingObject: object, message?: string, ...values: any[]): void
+  public fatal (mergingObject: any, message?: string, ...values: any[]): void {
     this.log('fatal', mergingObject, message, ...values)
   }
 

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -70,6 +70,58 @@ test.group('Logger', () => {
     ])
   })
 
+  test('log message as object at all log levels', (assert) => {
+    const messages: string[] = []
+
+    const logger = new Logger({
+      name: 'adonis-logger',
+      level: 'trace',
+      messageKey: 'msg',
+      enabled: true,
+      stream: getFakeStream((message) => {
+        messages.push(message.trim())
+        return true
+      }),
+    })
+
+    logger.trace({ hello: 'trace' })
+    logger.debug({ hello: 'debug' })
+    logger.info({ hello: 'info' })
+    logger.warn({ hello: 'warn' })
+    logger.error({ hello: 'error' })
+    logger.fatal({ hello: 'fatal' })
+
+    assert.deepEqual(messages.map((m) => {
+      const parsed = JSON.parse(m)
+      return { level: parsed.level, hello: parsed.hello }
+    }), [
+      {
+        level: 10,
+        hello: 'trace',
+      },
+      {
+        level: 20,
+        hello: 'debug',
+      },
+      {
+        level: 30,
+        hello: 'info',
+      },
+      {
+        level: 40,
+        hello: 'warn',
+      },
+      {
+        level: 50,
+        hello: 'error',
+      },
+      {
+        level: 60,
+        hello: 'fatal',
+      },
+    ])
+  })
+
   test('return current log level', (assert) => {
     const logger = new Logger({
       name: 'adonis-logger',


### PR DESCRIPTION
Make logger functionality more in line with vanilla pino

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

In the current version of `@adonisjs/logger` if you try to log an object i.e.

```js
import Logger from '@ioc:Adonis/Core/Logger'
...
Logger.info({ hello: 'info' })
```

you are presented with the error:

`Argument of type '{ hello: string; }' is not assignable to parameter of type 'string'.ts(2345)`

To workaround, you need to do an explicit type assertion as `any`:

```js
Logger.info({ hello: 'info' } as any)
```

Using vanilla `pino` this type assertion isn't required.

## Types of changes

- Streamlines `adonis-typings` so that all log level functions (`trace`, `debug`, etc.) all use a common interface
- Small changes to log method implementation overloads to remove the need for this explicit type assertion, and make it work like vanilla `pino`

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/logger/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
