### PR TITLE
fix: support falsy value in sprintf substitution

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -119,13 +119,7 @@ export class Logger implements LoggerContract {
   public log(level: string, message: string, ...values: any[]): void
   public log(level: string, mergingObject: any, message: string, ...values: any[]): void
   public log(level: string, mergingObject: any, message: string, ...values: any[]): void {
-    if (values.length) {
-      this.pino[level](mergingObject, message, ...values)
-    } else if (message) {
-      this.pino[level](mergingObject, message)
-    } else {
-      this.pino[level](mergingObject)
-    }
+    this.pino[level](mergingObject, message, ...values)
   }
 
   /**

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -90,6 +90,7 @@ test.group('Logger', () => {
     logger.info('hello %s', 'info')
     logger.info('hello %s %o', 'info', { url: '/' })
     logger.info('hello %s %j', 'info', { url: '/' })
+    logger.info('total: %d', 0)
 
     assert.deepEqual(
       messages.map((m) => {
@@ -108,6 +109,10 @@ test.group('Logger', () => {
         {
           level: 30,
           msg: `hello info ${JSON.stringify({ url: '/' })}`,
+        },
+        {
+          level: 30,
+          msg: 'total: 0',
         },
       ]
     )


### PR DESCRIPTION
Same as https://github.com/adonisjs/logger/pull/64 for Adonis 5
