### PR TITLE
feat: export type for LoggerLevel (pino.Level) from root module

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,3 +18,5 @@ export {
   stdSerializers,
   stdTimeFunctions,
 } from './src/pino.js'
+
+export type { Level as LoggerLevel } from './src/types.js'


### PR DESCRIPTION
### 🔗 Linked issue

None, as this is a very small change.

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Whilst working on a kafka package for Adonis v6, I needed the ability to type a `KAFKA_LOG_LEVEL` value, which is the same as the Pino log levels. I thought I could just do:

```
import type { Level } from '@adonisjs/core/logger'
```

But this doesn't work, instead I'd need to add `@adonisjs/logger` as a `devDependency` and `peerDependency` to our project, instead of just relying on `@adonisjs/core`, and then change that type import to:

```
import type { Level } from '@adonisjs/logger/types'
```

I feel like the former is probably a more expected way to use this type, hence opening this pull request.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
