### PR TITLE
Allow custom timestamp configuration

### DIFF
--- a/src/pino.ts
+++ b/src/pino.ts
@@ -41,6 +41,8 @@ export function createPino<Config extends LoggerConfig>(options: Config): PinoLo
    */
   if (typeof timestamp === 'string' && TimestampFormatters[timestamp]) {
     pinoOptions.timestamp = TimestampFormatters[timestamp]
+  } else if (typeof timestamp === 'boolean' || typeof timestamp === 'function') {
+    pinoOptions.timestamp = timestamp
   }
 
   return desination ? pino(pinoOptions, desination) : pino(pinoOptions)

--- a/tests/logger.spec.ts
+++ b/tests/logger.spec.ts
@@ -552,6 +552,44 @@ test.group('Logger', () => {
     assert.isNumber(JSON.parse(messages[0]).time)
   })
 
+  test('format timestamp using custom function', ({ assert }) => {
+    const messages: string[] = []
+
+    const logger = new Logger({
+      enabled: true,
+      timestamp: () => `,"eventTime":${Date.now()}`,
+      name: 'adonis-logger',
+      level: 'trace',
+      messageKey: 'msg',
+      desination: getFakeStream((message) => {
+        messages.push(message.trim())
+        return true
+      }),
+    })
+
+    logger.info('hello trace')
+    assert.isNumber(JSON.parse(messages[0]).eventTime)
+  })
+
+  test('disable timestamp logging', ({ assert }) => {
+    const messages: string[] = []
+
+    const logger = new Logger({
+      enabled: true,
+      timestamp: false,
+      name: 'adonis-logger',
+      level: 'trace',
+      messageKey: 'msg',
+      desination: getFakeStream((message) => {
+        messages.push(message.trim())
+        return true
+      }),
+    })
+
+    logger.info('hello trace')
+    assert.isUndefined(JSON.parse(messages[0]).time)
+  })
+
   test('log conditionally', async ({ assert }) => {
     let stack: string[] = []
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently only default presets for pino's timestamp option are allowed, however, this denies the ability to make a custom timestamp format or change the key of the timestamp field in log's json. This seems either like a bug or a missed feature.

I think a discussion for this is redundant as this is a very light change.
