### PR TITLE
fix: rename `desination` typo to `destination`

### DIFF
--- a/factories/logger.ts
+++ b/factories/logger.ts
@@ -47,7 +47,7 @@ export class LoggerFactory {
    */
   create() {
     if (this.#logsCollection) {
-      this.#options.desination = getFakeStream((message) => {
+      this.#options.destination = getFakeStream((message) => {
         this.#logsCollection!.push(message.trim())
         return true
       })

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -21,8 +21,8 @@ import type { LoggerConfig, LevelMapping, Bindings, ChildLoggerOptions } from '.
  *
  * - enabled: A flag to turn off the logger. You can still use the logger API, but
  *            nothing will be logged.
- * - destination: A stream to pass to pino as the desintation stream. With pino, you
- *                pass is at the 2nd argument, with Logger, you pass it as an option.
+ * - destination: A stream to pass to pino as the destination stream. With pino, you
+ *                pass it as the 2nd argument, with Logger, you pass it as an option.
  *
  * ```ts
  * const logger = new Logger({ enabled: true })
@@ -30,7 +30,7 @@ import type { LoggerConfig, LevelMapping, Bindings, ChildLoggerOptions } from '.
  * ```
  *
  * ```ts
- * const logger = new Logger({ enabled: true, desintation: pino.destination(2) })
+ * const logger = new Logger({ enabled: true, destination: pino.destination(2) })
  * logger.error('something went wrong')
  * ```
  */

--- a/src/pino.ts
+++ b/src/pino.ts
@@ -33,8 +33,9 @@ const TimestampFormatters: { [Keyword in TimestampKeywords]: () => string } = {
  * Returns an instance of pino logger by adjusting the config options
  */
 export function createPino<Config extends LoggerConfig>(options: Config): PinoLogger<string> {
-  const { desination, transport: configTransport, timestamp, ...rest } = options
-  const pinoOptions: LoggerOptions<any> = desination
+  const { destination: dest, desination, transport: configTransport, timestamp, ...rest } = options
+  const resolvedDestination = dest ?? desination
+  const pinoOptions: LoggerOptions<any> = resolvedDestination
     ? Object.assign({}, rest)
     : Object.assign({ transport: configTransport }, rest)
 
@@ -47,7 +48,7 @@ export function createPino<Config extends LoggerConfig>(options: Config): PinoLo
     pinoOptions.timestamp = timestamp
   }
 
-  return desination ? pino(pinoOptions, desination) : pino(pinoOptions)
+  return resolvedDestination ? pino(pinoOptions, resolvedDestination) : pino(pinoOptions)
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,10 @@ export type LoggerConfig = Omit<LoggerOptions<any>, 'browser' | 'timestamp'> & {
   /**
    * Destination stream for log output
    */
+  destination?: DestinationStream
+  /**
+   * @deprecated Use `destination` instead
+   */
   desination?: DestinationStream
   /**
    * Timestamp configuration - can be a keyword, boolean, or function

--- a/tests/logger.spec.ts
+++ b/tests/logger.spec.ts
@@ -22,7 +22,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'trace',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -78,7 +78,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'trace',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -153,7 +153,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'info',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -200,7 +200,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'trace',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -257,7 +257,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'info',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -367,7 +367,7 @@ test.group('Logger', () => {
           return { foo: levelNumber }
         },
       },
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -427,7 +427,7 @@ test.group('Logger', () => {
           return Object.assign({ ticked: true }, log)
         },
       },
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -493,7 +493,7 @@ test.group('Logger', () => {
           return Object.assign({ ticked: true }, log)
         },
       },
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -543,7 +543,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'trace',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -563,7 +563,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'trace',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -583,7 +583,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'trace',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -625,7 +625,7 @@ test.group('Logger', () => {
       customLevels: {
         foo: 35,
       },
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -655,7 +655,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'trace',
       messageKey: 'msg',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),
@@ -725,7 +725,7 @@ test.group('Logger', () => {
       name: 'adonis-logger',
       level: 'trace',
       messageKey: 'msg',
-      desination: await destinations.pretty({
+      destination: await destinations.pretty({
         sync: true,
         destination: getFakeStream((message) => {
           messages.push(message.trim())
@@ -758,5 +758,24 @@ test.group('Logger', () => {
 
     assert.include(messages[5], 'hello fatal')
     assert.include(messages[5], 'FATAL')
+  })
+
+  test('support deprecated "desination" option for backward compatibility', ({ assert }) => {
+    const messages: string[] = []
+
+    const logger = new Logger({
+      enabled: true,
+      level: 'info',
+      messageKey: 'msg',
+      desination: getFakeStream((message) => {
+        messages.push(message.trim())
+        return true
+      }),
+    })
+
+    logger.info('hello info')
+
+    assert.lengthOf(messages, 1)
+    assert.include(messages[0], 'hello info')
   })
 })

--- a/tests/logger_manager.spec.ts
+++ b/tests/logger_manager.spec.ts
@@ -51,7 +51,7 @@ test.group('Logger manager', () => {
         main: {
           enabled: true,
           level: 'trace',
-          desination: getFakeStream((message) => {
+          destination: getFakeStream((message) => {
             messages.push(message.trim())
             return true
           }),
@@ -113,7 +113,7 @@ test.group('Logger manager', () => {
         main: {
           enabled: true,
           level: 'trace',
-          desination: getFakeStream((message) => {
+          destination: getFakeStream((message) => {
             messages.push(message.trim())
             return true
           }),
@@ -173,7 +173,7 @@ test.group('Logger manager', () => {
         main: {
           enabled: false,
           level: 'trace',
-          desination: getFakeStream((message) => {
+          destination: getFakeStream((message) => {
             messages.push(message.trim())
             return true
           }),
@@ -208,7 +208,7 @@ test.group('Logger manager', () => {
         main: {
           enabled: true,
           level: 'trace',
-          desination: getFakeStream((message) => {
+          destination: getFakeStream((message) => {
             messages.push(message.trim())
             return true
           }),
@@ -221,7 +221,7 @@ test.group('Logger manager', () => {
     const logger = manager.create({
       enabled: true,
       level: 'warn',
-      desination: getFakeStream((message) => {
+      destination: getFakeStream((message) => {
         messages.push(message.trim())
         return true
       }),


### PR DESCRIPTION
keeping `desination` for retro-compatbility + mark it as `@deprecated` 